### PR TITLE
feat: add Discord notifications for PR reviews and events

### DIFF
--- a/.github/workflows/discord_notif.yml
+++ b/.github/workflows/discord_notif.yml
@@ -1,0 +1,11 @@
+name: "🚀 PR → 💬 Discord Notifications"
+on:
+    pull_request_review:
+        types: [submitted]
+    pull_request:
+        types: [opened, closed, ready_for_review, converted_to_draft, reopened]
+
+jobs:
+    notify:
+        uses: ESP-Corevia/.github/.github/workflows/pr_review_notification.yml@master
+        secrets: inherit


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notes de Version

* **Chores**
  * Ajout d'une automatisation pour les notifications Discord lors des événements liés aux demandes de fusion. Le système notifiera désormais les changements d'état des pull requests (ouverture, fermeture, statut prêt pour révision, etc.) via Discord.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->