### PR TITLE
chore: release master

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "apps/web": "1.1.0",
-  "apps/server": "1.1.0",
+  "apps/server": "1.1.1",
   "apps/home": "1.1.0"
 }

--- a/apps/server/CHANGELOG.md
+++ b/apps/server/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.1.1](https://github.com/ESP-Corevia/CoreApp/compare/server-v1.1.0...server-v1.1.1) (2026-01-23)
+
+
+### 🐛 Fixes
+
+* **tsdown:** add outExtensions function to specify output file extensions ([#53](https://github.com/ESP-Corevia/CoreApp/issues/53)) ([b93b109](https://github.com/ESP-Corevia/CoreApp/commit/b93b10981f494b20ef8aa2b582f21b87311b6b81))
+
+
+### 🔧 Chores
+
+* release master ([#54](https://github.com/ESP-Corevia/CoreApp/issues/54)) ([aa9a4ca](https://github.com/ESP-Corevia/CoreApp/commit/aa9a4ca79be3fdd0cdec5e58de0a73f2a59f3fb8))
+
 ## [1.1.0](https://github.com/ESP-Corevia/CoreApp/compare/server-v1.0.0...server-v1.1.0) (2026-01-16)
 
 

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -2,7 +2,7 @@
   "name": "server",
   "main": "src/index.ts",
   "type": "module",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "scripts": {
     "build": "tsdown",
     "check-types": "tsc -b",


### PR DESCRIPTION
:robot: Corevia Release
---


<details><summary>server: 1.1.1</summary>

## [1.1.1](https://github.com/ESP-Corevia/CoreApp/compare/server-v1.1.0...server-v1.1.1) (2026-01-23)


### 🐛 Fixes

* **tsdown:** add outExtensions function to specify output file extensions ([#53](https://github.com/ESP-Corevia/CoreApp/issues/53)) ([b93b109](https://github.com/ESP-Corevia/CoreApp/commit/b93b10981f494b20ef8aa2b582f21b87311b6b81))


### 🔧 Chores

* release master ([#54](https://github.com/ESP-Corevia/CoreApp/issues/54)) ([aa9a4ca](https://github.com/ESP-Corevia/CoreApp/commit/aa9a4ca79be3fdd0cdec5e58de0a73f2a59f3fb8))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).