### PR TITLE
chore: release master

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -145,9 +145,9 @@ jobs:
 
   migrations:
     runs-on: ubuntu-latest
-    name: 🐘 Drizzle Migrations Check & Apply
+    name: 🐘 Drizzle Migrations Check
     needs: lint
-    # if: needs.lint.outputs.migrations_changed == 'true'
+    if: needs.lint.outputs.migrations_changed == 'true'
     services:
       postgres:
         image: postgres:16

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "apps/web": "1.1.0",
-  "apps/server": "1.2.0",
+  "apps/server": "1.3.0",
   "apps/home": "1.1.0"
 }

--- a/apps/server/CHANGELOG.md
+++ b/apps/server/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.3.0](https://github.com/ESP-Corevia/CoreApp/compare/server-v1.2.0...server-v1.3.0) (2026-01-29)
+
+
+### ✨ Features
+
+* add migration test in ci and renovate ([#60](https://github.com/ESP-Corevia/CoreApp/issues/60)) ([4645de8](https://github.com/ESP-Corevia/CoreApp/commit/4645de8caa7f1eff2777249c614092873c79bc7d))
+
 ## [1.2.0](https://github.com/ESP-Corevia/CoreApp/compare/server-v1.1.1...server-v1.2.0) (2026-01-23)
 
 

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -2,7 +2,7 @@
   "name": "server",
   "main": "src/index.ts",
   "type": "module",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "scripts": {
     "build": "tsdown",
     "check-types": "tsc -b",


### PR DESCRIPTION
:robot: Corevia Release
---


<details><summary>server: 1.3.0</summary>

## [1.3.0](https://github.com/ESP-Corevia/CoreApp/compare/server-v1.2.0...server-v1.3.0) (2026-01-29)


### ✨ Features

* add migration test in ci and renovate ([#60](https://github.com/ESP-Corevia/CoreApp/issues/60)) ([4645de8](https://github.com/ESP-Corevia/CoreApp/commit/4645de8caa7f1eff2777249c614092873c79bc7d))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).