### PR TITLE
chore: release master

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "apps/web": "1.1.0",
-  "apps/server": "1.1.0",
+  "apps/server": "1.1.1",
   "apps/home": "1.0.0"
 }

--- a/apps/server/CHANGELOG.md
+++ b/apps/server/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.1.1 (2026-03-25)
+
+## What's Changed
+* fix(deps): update server (drizzle) by @renovate[bot] in https://github.com/ESP-Corevia/CoreApp/pull/111
+* fix(deps): update server (postgres) to v8.20.0 by @renovate[bot] in https://github.com/ESP-Corevia/CoreApp/pull/112
+
+
+**Full Changelog**: https://github.com/ESP-Corevia/CoreApp/compare/server-v1.1.0...server-v1.1.1
+
 ## [1.1.0](https://github.com/ESP-Corevia/CoreApp/compare/server-v1.0.0...server-v1.1.0) (2026-03-25)
 
 

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -66,5 +66,5 @@
     "zod-openapi": "5.3.1"
   },
   "packageManager": "pnpm@10.12.1",
-  "version": "1.1.0"
+  "version": "1.1.1"
 }


### PR DESCRIPTION
:robot: Corevia Release
---


<details><summary>server: 1.1.1</summary>

## 1.1.1 (2026-03-25)

## What's Changed
* fix(deps): update server (drizzle) by @renovate[bot] in https://github.com/ESP-Corevia/CoreApp/pull/111
* fix(deps): update server (postgres) to v8.20.0 by @renovate[bot] in https://github.com/ESP-Corevia/CoreApp/pull/112


**Full Changelog**: https://github.com/ESP-Corevia/CoreApp/compare/server-v1.1.0...server-v1.1.1
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).