### PR TITLE
chore: release master

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "apps/web": "1.1.0",
-  "apps/server": "1.1.1",
+  "apps/server": "1.1.2",
   "apps/home": "1.0.0"
 }

--- a/apps/server/CHANGELOG.md
+++ b/apps/server/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 1.1.2 (2026-03-30)
+
+## What's Changed
+* fix(deps): update dependency pino to v10 by @renovate[bot] in https://github.com/ESP-Corevia/CoreApp/pull/116
+* chore(deps): update pnpm/action-setup action to v5 by @renovate[bot] in https://github.com/ESP-Corevia/CoreApp/pull/115
+* chore(deps): update dorny/paths-filter action to v4 by @renovate[bot] in https://github.com/ESP-Corevia/CoreApp/pull/114
+* Pnpm docker by @Yasser5711 in https://github.com/ESP-Corevia/CoreApp/pull/118
+* Admin appointments by @Yasser5711 in https://github.com/ESP-Corevia/CoreApp/pull/119
+
+
+**Full Changelog**: https://github.com/ESP-Corevia/CoreApp/compare/server-v1.1.1...server-v1.1.2
+
 ## 1.1.1 (2026-03-25)
 
 ## What's Changed

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -67,5 +67,5 @@
     "zod-openapi": "5.3.1"
   },
   "packageManager": "pnpm@10.12.1",
-  "version": "1.1.1"
+  "version": "1.1.2"
 }


### PR DESCRIPTION
:robot: Corevia Release
---


<details><summary>server: 1.1.2</summary>

## 1.1.2 (2026-03-30)

## What's Changed
* fix(deps): update dependency pino to v10 by @renovate[bot] in https://github.com/ESP-Corevia/CoreApp/pull/116
* chore(deps): update pnpm/action-setup action to v5 by @renovate[bot] in https://github.com/ESP-Corevia/CoreApp/pull/115
* chore(deps): update dorny/paths-filter action to v4 by @renovate[bot] in https://github.com/ESP-Corevia/CoreApp/pull/114
* Pnpm docker by @Yasser5711 in https://github.com/ESP-Corevia/CoreApp/pull/118
* Admin appointments by @Yasser5711 in https://github.com/ESP-Corevia/CoreApp/pull/119


**Full Changelog**: https://github.com/ESP-Corevia/CoreApp/compare/server-v1.1.1...server-v1.1.2
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).